### PR TITLE
fix: add user fallback to get_or_fetch_member

### DIFF
--- a/lib/helpers/cache.py
+++ b/lib/helpers/cache.py
@@ -30,7 +30,7 @@ async def get_or_fetch_message(
 
 async def get_or_fetch_member(
     bot: TitaniumBot, guild: discord.Guild, user_id: int
-) -> discord.Member | None:
+) -> discord.Member | discord.User | None:
     # Try to get the member from cache
     member = guild.get_member(user_id)
     if member:
@@ -42,6 +42,15 @@ async def get_or_fetch_member(
         LOGGER.debug(f"Fetching member from Discord (guild: {guild.id}, user: {user_id})")
         member = await guild.fetch_member(user_id)
         return member
+    except discord.NotFound:
+        pass
+
+    # Fallback: if user left the guild or never joined, fetch as User
+    # This is useful for populating member/user info in the dashboard
+    try:
+        LOGGER.debug(f"Member not in guild, falling back to user fetch (user: {user_id})")
+        user = await bot.fetch_user(user_id)
+        return user
     except discord.NotFound:
         return None
 

--- a/pr_body_192.txt
+++ b/pr_body_192.txt
@@ -1,0 +1,14 @@
+## Summary
+
+When `get_or_fetch_member` fails to find a user as a guild member (e.g. they left the server), it previously returned `None`. This adds a fallback to `bot.fetch_user()` so callers still get useful `discord.User` info (username, avatar, etc.) instead of nothing.
+
+## Changes
+
+- `lib/helpers/cache.py`: After `guild.fetch_member()` raises `discord.NotFound`, try `bot.fetch_user(user_id)` as a fallback
+- Return type expanded from `discord.Member | None` to `discord.Member | discord.User | None`
+
+## Motivation
+
+This is useful for populating member/user information in the dashboard and other contexts where a user may have left the guild but their basic profile info is still needed.
+
+Closes #192


### PR DESCRIPTION
## Summary

When `get_or_fetch_member` fails to find a user as a guild member (e.g. they left the server), it previously returned `None`. This adds a fallback to `bot.fetch_user()` so callers still get useful `discord.User` info (username, avatar, etc.) instead of nothing.

## Changes

- `lib/helpers/cache.py`: After `guild.fetch_member()` raises `discord.NotFound`, try `bot.fetch_user(user_id)` as a fallback
- Return type expanded from `discord.Member | None` to `discord.Member | discord.User | None`

## Motivation

This is useful for populating member/user information in the dashboard and other contexts where a user may have left the guild but their basic profile info is still needed.

Closes #192