### PR TITLE
Add Prometheus metrics

### DIFF
--- a/cogs/api/api.py
+++ b/cogs/api/api.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import discord
 from aiohttp import web
 from discord.ext import commands
+from prometheus_client.aiohttp import make_aiohttp_handler
 from pydantic import ValidationError
 from sqlalchemy import delete, func, select
 from sqlalchemy.exc import IntegrityError
@@ -148,6 +149,8 @@ class APICog(commands.Cog):
     def register_routes(self):
         if self.app is None:
             return
+
+        self.app.router.add_get("/metrics", make_aiohttp_handler())
 
         self.app.router.add_get("/", self.index)
         self.app.router.add_get("/info", self.info)

--- a/cogs/automated/analytics.py
+++ b/cogs/automated/analytics.py
@@ -21,6 +21,23 @@ class Analytics(commands.Cog):
     def __init__(self, bot: TitaniumBot) -> None:
         self.bot = bot
 
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        # set all labels on start
+        # this makes the count more accurate when the bot restarts
+
+        for command in self.bot.tree.walk_commands():
+            commands_counter.labels(
+                name=command.qualified_name,
+                type="app_command",
+            )
+
+        for command in self.bot.walk_commands():
+            commands_counter.labels(
+                name=command.qualified_name,
+                type="prefix",
+            )
+
     async def _send_embed(self, embed: discord.Embed, raw: bool = False) -> None:
         if self.bot.user:
             embed.set_author(

--- a/cogs/automated/analytics.py
+++ b/cogs/automated/analytics.py
@@ -4,9 +4,17 @@ from typing import TYPE_CHECKING
 import discord
 from discord import Colour, app_commands
 from discord.ext import commands
+from prometheus_client import Counter
 
 if TYPE_CHECKING:
     from main import TitaniumBot
+
+
+commands_counter = Counter(
+    "commands_executed",
+    "Total commands executed",
+    ["name", "type"],
+)
 
 
 class Analytics(commands.Cog):
@@ -39,6 +47,12 @@ class Analytics(commands.Cog):
         interaction: discord.Interaction["TitaniumBot"],
         command: app_commands.Command | app_commands.ContextMenu,
     ) -> None:
+        # Set prometheus
+        commands_counter.labels(
+            name=command.qualified_name,
+            type="app_command",
+        ).inc()
+
         if (
             interaction.command
             and command.qualified_name.startswith("anonymous ")
@@ -56,23 +70,17 @@ class Analytics(commands.Cog):
 
         await self._send_embed(embed)
 
-    # Analytics for raw interactions
-    @commands.Cog.listener()
-    async def on_interaction(self, interaction: discord.Interaction["TitaniumBot"]):
-        embed = discord.Embed(
-            title=f"`@{interaction.user.name}` started an interaction",
-            description=f"`{interaction.type}`",
-            timestamp=interaction.created_at,
-        )
-        embed.add_field(name="User", value=f"{interaction.user.mention} (`{interaction.user.id}`)")
-
-        await self._send_embed(embed, raw=True)
-
     # Analytics for prefix commands
     @commands.Cog.listener()
-    async def on_command(self, ctx: commands.Context["TitaniumBot"]):
+    async def on_command_completion(self, ctx: commands.Context["TitaniumBot"]):
         if ctx.command is None or ctx.interaction:
             return
+
+        # Set prometheus
+        commands_counter.labels(
+            name=ctx.command.qualified_name,
+            type="prefix",
+        ).inc()
 
         if (
             ctx.command.qualified_name.startswith("anonymous ")
@@ -89,6 +97,40 @@ class Analytics(commands.Cog):
         embed.add_field(name="User", value=f"{ctx.author.mention} (`{ctx.author.id}`)")
 
         await self._send_embed(embed)
+
+    # Analytics for raw interactions
+    @commands.Cog.listener()
+    async def on_interaction(self, interaction: discord.Interaction["TitaniumBot"]):
+        embed = discord.Embed(
+            title=f"`@{interaction.user.name}` started an interaction",
+            description=f"`{interaction.type}`",
+            timestamp=interaction.created_at,
+        )
+        embed.add_field(name="User", value=f"{interaction.user.mention} (`{interaction.user.id}`)")
+
+        await self._send_embed(embed, raw=True)
+
+    # Analytics for raw commands
+    @commands.Cog.listener()
+    async def on_command(self, ctx: commands.Context["TitaniumBot"]):
+        if ctx.command is None or ctx.interaction:
+            return
+
+        if (
+            ctx.command.qualified_name.startswith("anonymous ")
+            and ctx.guild
+            and ctx.guild.id in self.bot.trusted_servers
+        ):
+            return
+
+        embed = discord.Embed(
+            title=f"`@{ctx.author.name}` started a prefix command",
+            description=f"`{ctx.clean_prefix}{ctx.command.qualified_name}`",
+            timestamp=ctx.message.created_at,
+        )
+        embed.add_field(name="User", value=f"{ctx.author.mention} (`{ctx.author.id}`)")
+
+        await self._send_embed(embed, raw=True)
 
     # Analytics for server joins
     @commands.Cog.listener()

--- a/cogs/automated/prometheus.py
+++ b/cogs/automated/prometheus.py
@@ -1,0 +1,52 @@
+from typing import TYPE_CHECKING
+
+from discord.ext import commands, tasks
+from prometheus_client import Gauge
+from sqlalchemy import func, select
+
+from lib.sql.sql import GuildSettings, ModCase, ScheduledTask, get_session
+
+if TYPE_CHECKING:
+    from main import TitaniumBot
+
+
+scheduled_task_amounts = Gauge("scheduled_task_amount", "Amount of pending scheduled tasks")
+mod_case_amounts = Gauge("stored_mod_cases", "Amount of stored mod cases in database")
+guild_config_amounts = Gauge("stored_guild_configs", "Amount of stored guild configs in database")
+
+
+class PrometheusCog(commands.Cog):
+    """Automatic task and event handlers to update some prometheus stats"""
+
+    def __init__(self, bot: TitaniumBot) -> None:
+        self.bot = bot
+
+    async def cog_load(self) -> None:
+        # Start tasks
+        self.counter_update.start()
+
+    async def cog_unload(self) -> None:
+        # Stop tasks on unload
+        self.counter_update.cancel()
+
+    # Prometheus update task
+    @tasks.loop(minutes=1)
+    async def counter_update(self) -> None:
+        await self.bot.wait_until_ready()
+
+        async with get_session() as session:
+            scheduled_task_amounts.set(
+                (await session.execute(select(func.count()).select_from(ScheduledTask))).scalar()
+                or 0
+            )
+            mod_case_amounts.set(
+                (await session.execute(select(func.count()).select_from(ModCase))).scalar() or 0
+            )
+            guild_config_amounts.set(
+                (await session.execute(select(func.count()).select_from(GuildSettings))).scalar()
+                or 0
+            )
+
+
+async def setup(bot: TitaniumBot):
+    await bot.add_cog(PrometheusCog(bot))

--- a/cogs/automated/scheduled_tasks.py
+++ b/cogs/automated/scheduled_tasks.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import discord
 from discord.ext import commands, tasks
 from discord.utils import utcnow
+from prometheus_client import Gauge
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
@@ -19,6 +20,10 @@ from lib.views.polls import ClosedPollView
 
 if TYPE_CHECKING:
     from main import TitaniumBot
+
+scheduled_tasks_queue_length = Gauge(
+    "scheduled_task_queue_length", "Amount of scheduled tasks in the processing queue"
+)
 
 
 class ScheduledTasksCog(commands.Cog):
@@ -41,9 +46,11 @@ class ScheduledTasksCog(commands.Cog):
             self.bot.loop.create_task(self.queue_worker())
 
         self.task_fetcher.start()
+        self.prometheus_update.start()
 
     async def cog_unload(self) -> None:
         self.task_fetcher.cancel()
+        self.prometheus_update.cancel()
         self.task_queue.shutdown(immediate=True)
 
     async def queue_worker(self):
@@ -482,6 +489,10 @@ class ScheduledTasksCog(commands.Cog):
                     self.logger.debug(f"Adding task {task.id} to queue")
                     self.waiting_tasks.append(task.id)
                 await self.task_queue.put(task)
+
+    @tasks.loop(seconds=1)
+    async def prometheus_update(self) -> None:
+        scheduled_tasks_queue_length.set(self.task_queue.qsize())
 
 
 async def setup(bot: TitaniumBot) -> None:

--- a/cogs/automated/stats_update.py
+++ b/cogs/automated/stats_update.py
@@ -5,9 +5,18 @@ from typing import TYPE_CHECKING
 import discord
 from discord.ext import commands, tasks
 from discord.http import Route
+from prometheus_client import Gauge
 
 if TYPE_CHECKING:
     from main import TitaniumBot
+
+
+ws_latency = Gauge("ws_latency", "Discord Websocket latency")
+api_latency = Gauge("dc_api_latency", "Discord API latency")
+
+user_installs = Gauge("user_installs", "Amount of user installs")
+guild_installs = Gauge("guild_installs", "Amount of guild installs / total guild count")
+guild_member_count = Gauge("guild_member_count", "Amount of members across all guilds")
 
 
 class StatsUpdateCog(commands.Cog):
@@ -48,6 +57,11 @@ class StatsUpdateCog(commands.Cog):
         )
         self.bot.guild_installs = len(self.bot.guilds)
         self.bot.guild_member_count = guild_members
+
+        # Set prometheus
+        user_installs.set(self.bot.user_installs)
+        guild_installs.set(self.bot.guild_installs)
+        guild_member_count.set(self.bot.guild_member_count)
 
     # Status update task
     @tasks.loop(minutes=10)
@@ -102,6 +116,10 @@ class StatsUpdateCog(commands.Cog):
         except Exception as e:
             self.bot.api_latency = 0
             logging.error("Failed to measure API latency", exc_info=e)
+        finally:
+            # Set prometheus
+            ws_latency.set(self.bot.latency * 1000)
+            api_latency.set(self.bot.api_latency * 1000)
 
 
 async def setup(bot: TitaniumBot):

--- a/cogs/automated/stats_update.py
+++ b/cogs/automated/stats_update.py
@@ -5,14 +5,16 @@ from typing import TYPE_CHECKING
 import discord
 from discord.ext import commands, tasks
 from discord.http import Route
-from prometheus_client import Gauge
+from prometheus_client import Gauge, Histogram
 
 if TYPE_CHECKING:
     from main import TitaniumBot
 
 
-ws_latency = Gauge("ws_latency", "Discord Websocket latency")
-api_latency = Gauge("dc_api_latency", "Discord API latency")
+ws_latency_now = Gauge("dc_ws_latency_now", "Discord Websocket latency - live")
+api_latency_now = Gauge("dc_api_latency_now", "Discord API latency - live")
+ws_latency = Histogram("dc_ws_latency", "Discord Websocket latency")
+api_latency = Histogram("dc_api_latency", "Discord API latency")
 
 user_installs = Gauge("user_installs", "Amount of user installs")
 guild_installs = Gauge("guild_installs", "Amount of guild installs / total guild count")
@@ -105,6 +107,10 @@ class StatsUpdateCog(commands.Cog):
     # Measure API latency task
     @tasks.loop(minutes=1)
     async def measure_api_latency(self) -> None:
+        if self.bot.latency >= 0:
+            ws_latency_now.set(self.bot.latency)
+            ws_latency.observe(self.bot.latency)
+
         try:
             start = time.perf_counter()
             r = Route("GET", "/users/@me")
@@ -113,13 +119,11 @@ class StatsUpdateCog(commands.Cog):
             delta = time.perf_counter() - start
 
             self.bot.api_latency = delta
+            api_latency_now.set(delta)
+            api_latency.observe(delta)
         except Exception as e:
             self.bot.api_latency = 0
             logging.error("Failed to measure API latency", exc_info=e)
-        finally:
-            # Set prometheus
-            ws_latency.set(self.bot.latency * 1000)
-            api_latency.set(self.bot.api_latency * 1000)
 
 
 async def setup(bot: TitaniumBot):

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ import discord
 from discord.ext import commands
 from discord.utils import utcnow
 from dotenv import load_dotenv
+from prometheus_client import Counter
 from rapidfuzz import fuzz, process, utils
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert
@@ -63,6 +64,13 @@ from lib.sql.sql import (
 
 # Current Running Path
 path = os.getcwd()
+
+# error counter
+error_counter = Counter(
+    "errors",
+    "Total amount of errors encountered",
+    ["name", "type"],
+)
 
 # setup the logging
 setup_logging()
@@ -431,6 +439,11 @@ class TitaniumBot(commands.Bot):
         if not isinstance(exc, Exception):
             exc = None
 
+        error_counter.labels(
+            name=type(exc).__qualname__ if exc else "Unknown",
+            type="python",
+        ).inc()
+
         try:
             await log_error(
                 bot=self,
@@ -543,6 +556,11 @@ async def check(ctx: commands.Context["TitaniumBot"]):
 async def on_command_error(ctx: commands.Context["TitaniumBot"], error: commands.CommandError):
     ephemeral = True
     original_error = getattr(error, "original", error)
+
+    error_counter.labels(
+        name=type(original_error).__qualname__,
+        type="command",
+    ).inc()
 
     if isinstance(original_error, (img_tools.ImageTooSmallError, img_tools.OperationTooLargeError)):
         description = (
@@ -712,6 +730,11 @@ async def on_app_command_error(
     interaction: discord.Interaction["TitaniumBot"], error: discord.app_commands.AppCommandError
 ):
     original_error = getattr(error, "original", error)
+
+    error_counter.labels(
+        name=type(original_error).__qualname__,
+        type="app_command",
+    ).inc()
 
     if isinstance(original_error, (img_tools.ImageTooSmallError, img_tools.OperationTooLargeError)):
         description = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "jinja2>=3.1.6",
     "pillow>=12.3.0",
     "playwright>=1.62.0",
+    "prometheus-client>=0.26.0",
     "psutil>=7.1.3",
     "py-cpuinfo>=9.0.0",
     "pydantic>=2.13.4",

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -865,6 +874,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "pillow" },
     { name = "playwright" },
+    { name = "prometheus-client" },
     { name = "psutil" },
     { name = "py-cpuinfo" },
     { name = "pydantic" },
@@ -896,6 +906,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "playwright", specifier = ">=1.62.0" },
+    { name = "prometheus-client", specifier = ">=0.26.0" },
     { name = "psutil", specifier = ">=7.1.3" },
     { name = "py-cpuinfo", specifier = ">=9.0.0" },
     { name = "pydantic", specifier = ">=2.13.4" },


### PR DESCRIPTION
Titanium now exposes Prometheus metrics on the /metrics endpoint of the internal API, as always this API should not be available externally. Closes #220